### PR TITLE
Added icon for the iPad Pro, fixed indentation in one place, and added a new resource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,9 @@ If you're obsessive, you want all this too:
 1. Largest to smallest apple-touch-icons [3]_:
 
     .. code-block:: html
-		<!-- For Iphone 6 plus running iOS 8: -->
-		<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/path/to/favicon-180.png">
+    
+	<!-- For Iphone 6 plus running iOS 8: -->
+	<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/path/to/favicon-180.png">
 	
 	<!-- For the iPad Pro -->
 	<link rel="apple-touch-icon-precomposed" sizes="167x167" href="/path/to/favicon-167.png">

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,9 @@ If you're obsessive, you want all this too:
     .. code-block:: html
 		<!-- For Iphone 6 plus running iOS 8: -->
 		<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/path/to/favicon-180.png">
+	
+	<!-- For the iPad Pro -->
+	<link rel="apple-touch-icon-precomposed" sizes="167x167" href="/path/to/favicon-167.png">
 		
         <!-- For iPad with high-resolution Retina display running iOS ≥ 7: -->
         <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/path/to/favicon-152.png">
@@ -149,6 +152,7 @@ Size    Name            Purpose
 128x128	smalltile.png	Small Windows 8 Star Screen Icon
 144x144 favicon-144.png IE10 Metro tile for pinned site
 152x152 favicon-152.png iPad retina touch icon (Change for iOS 7: up from 144x144)
+167x167 favicon-167.png iPad Pro
 180x180 favicon-180.png iPhone 6 plus
 195x195 favicon-195.png Opera Speed Dial icon (Not working in Opera 15 and later)
 196x196 favicon-196.png Chrome for Android home screen icon

--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,7 @@ I recommend:
 Others that I haven't tried:
 
 * Favic-o-matic: http://www.favicomatic.com - A favicon generator that cares of .ico, .png and HTML code to make your website shine on every platform, browser or device
+* Real Favicon Generator: https://realfavicongenerator.net - Another favicon generator that generates and lets you customize all the icons you could ever want.
 * Ubuntu/Debian package `icoutil` (Fedora package `icoutils`_) provides the program `icotool` which creates .ico from .png files.
 * MSDN recommends this web-based .ico creator: http://www.xiconeditor.com
 * Resize favicons: http://faviconer.com


### PR DESCRIPTION
- According to [iOS human interface guidelines](https://developer.apple.com/ios/human-interface-guidelines/graphics/app-icon/#//apple_ref/doc/uid/TP40006556-CH27), the iPad Pro uses 167x167 icons. So added new icons

- Added (Real Favicon Generator)[https://realfavicongenerator.net] to resources. Sounds like a gimmick, but is a pretty good tool.

- Seems like there was something wrong with indentation at lines 84-85, which prevented the apple touch icon code to be seen, so fixed that.