### PR TITLE
Net Magazine featured link changed to source link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ A painfully obsessive cheat sheet to favicon sizes/types. Compiled from:
 * http://www.jonathantneal.com/blog/understand-the-favicon/
 * https://en.wikipedia.org/wiki/Favicon.ico
 * http://snook.ca/archives/design/making_a_good_favicon
-* http://www.netmagazine.com/features/create-perfect-favicon
+* http://www.creativebloq.com/illustrator/create-perfect-favicon-12112760
 * http://www.ravelrumba.com/blog/android-apple-touch-icon/
 * http://msdn.microsoft.com/en-us/library/ie/gg491740(v=vs.85).aspx
 


### PR DESCRIPTION
Net Magazine featured link isn't working any more. If I've made my search right, this is the correct link on the article source.