### PR TITLE
Fix 'Largest to smallest apple-touch-icons' code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,10 @@ If you're obsessive, you want all this too:
 1. Largest to smallest apple-touch-icons [3]_:
 
     .. code-block:: html
-		<!-- For Iphone 6 plus running iOS 8: -->
-		<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/path/to/favicon-180.png">
-		
+
+        <!-- For Iphone 6 plus running iOS 8: -->
+        <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/path/to/favicon-180.png">
+
         <!-- For iPad with high-resolution Retina display running iOS ≥ 7: -->
         <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/path/to/favicon-152.png">
 
@@ -146,16 +147,16 @@ Size    Name            Purpose
 96x96   favicon-96.png  GoogleTV icon
 120x120 favicon-120.png iPhone retina touch icon (Change for iOS 7: up from 114x114)
 128x128 favicon-128.png Chrome Web Store icon
-128x128	smalltile.png	Small Windows 8 Star Screen Icon
+128x128 smalltile.png   Small Windows 8 Star Screen Icon
 144x144 favicon-144.png IE10 Metro tile for pinned site
 152x152 favicon-152.png iPad retina touch icon (Change for iOS 7: up from 144x144)
 180x180 favicon-180.png iPhone 6 plus
 195x195 favicon-195.png Opera Speed Dial icon (Not working in Opera 15 and later)
 196x196 favicon-196.png Chrome for Android home screen icon
 228x228 favicon-228.png Opera Coast icon
-270x270	mediumtile.png	Medium Windows 8 Start Screen Icon
-558x270	widetile.png	Wide Windows 8 Start Screen Icon
-558x558	largetile.png	Large Windows 8 Start Screen Icon
+270x270 mediumtile.png  Medium Windows 8 Start Screen Icon
+558x270 widetile.png    Wide Windows 8 Start Screen Icon
+558x558 largetile.png   Large Windows 8 Start Screen Icon
 ======= =============== =======================================================================
 
 ICO File


### PR DESCRIPTION
Hi Audrey.

I've added a little fix to 'Largest to smallest apple-touch-icons' code example. Without empty line between code block definition and markup this block is invisible on github page https://github.com/audreyr/favicon-cheat-sheet/blob/master/README.rst

Also I've found several tabs in code. All other lines indented with spaces and I decided that it is a bug. Replaced tabs to spaces.